### PR TITLE
Add run analytics dashboard

### DIFF
--- a/app/_components/top-bar.tsx
+++ b/app/_components/top-bar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { FolderGit2, Plus } from "lucide-react";
+import Link from "next/link";
+import { BarChart3, FolderGit2, Plus } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -77,6 +78,12 @@ export function TopBar({
           )}
         </div>
 
+        <Button variant="outline" size="sm" className="h-7 text-xs gap-1" asChild>
+          <Link href="/analytics">
+            <BarChart3 className="h-3.5 w-3.5" />
+            <span className="hidden sm:inline">Analytics</span>
+          </Link>
+        </Button>
         <Button variant="outline" size="sm" className="h-7 text-xs gap-1" onClick={onManageRepos}>
           <FolderGit2 className="h-3.5 w-3.5" />
           <span className="hidden sm:inline">Repos</span>

--- a/app/analytics/_components/analytics-dashboard.tsx
+++ b/app/analytics/_components/analytics-dashboard.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+import { useAnalytics, type RecentFailure, type StageMetrics } from "./use-analytics";
+
+function formatDuration(ms: number | null): string {
+  if (ms === null) return "--";
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  const seconds = ms / 1000;
+  if (seconds < 60) return `${seconds.toFixed(1)}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remainingSec = Math.round(seconds % 60);
+  return `${minutes}m ${remainingSec}s`;
+}
+
+function formatPercent(value: number | null): string {
+  if (value === null) return "--";
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function SummaryCards({
+  totalRuns,
+  successRate,
+  avgDurationMs,
+  activeRuns,
+}: {
+  totalRuns: number;
+  successRate: number | null;
+  avgDurationMs: number | null;
+  activeRuns: number;
+}) {
+  const cards = [
+    { label: "Total Runs", value: String(totalRuns) },
+    { label: "Success Rate", value: formatPercent(successRate) },
+    { label: "Avg Duration", value: formatDuration(avgDurationMs) },
+    { label: "Active Runs", value: String(activeRuns) },
+  ];
+
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+      {cards.map((card) => (
+        <Card key={card.label} className="py-4">
+          <CardContent className="px-4 py-0">
+            <p className="text-xs text-muted-foreground">{card.label}</p>
+            <p className="text-2xl font-bold tracking-tight mt-1">{card.value}</p>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+function StageBreakdownTable({ stages }: { stages: StageMetrics[] }) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-sm">Stage Breakdown</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="border-b text-muted-foreground">
+                <th className="text-left py-2 pr-4 font-medium">Stage</th>
+                <th className="text-right py-2 px-3 font-medium">Runs</th>
+                <th className="text-right py-2 px-3 font-medium">Success</th>
+                <th className="text-right py-2 px-3 font-medium">Failed</th>
+                <th className="text-right py-2 px-3 font-medium">Skipped</th>
+                <th className="text-right py-2 pl-3 font-medium">Avg Duration</th>
+              </tr>
+            </thead>
+            <tbody>
+              {stages.map((stage) => (
+                <tr key={stage.name} className="border-b last:border-0">
+                  <td className="py-2 pr-4 font-medium">{stage.name}</td>
+                  <td className="text-right py-2 px-3 tabular-nums">{stage.total}</td>
+                  <td className="text-right py-2 px-3 tabular-nums text-[var(--status-done)]">{stage.success}</td>
+                  <td className="text-right py-2 px-3 tabular-nums text-[var(--status-failed)]">{stage.failed}</td>
+                  <td className="text-right py-2 px-3 tabular-nums text-muted-foreground">{stage.skipped}</td>
+                  <td className="text-right py-2 pl-3 tabular-nums">{formatDuration(stage.avgDurationMs)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function RecentFailuresList({ failures }: { failures: RecentFailure[] }) {
+  if (failures.length === 0) {
+    return (
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-sm">Recent Failures</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-xs text-muted-foreground">No failures recorded.</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-sm">Recent Failures</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {failures.map((failure, idx) => (
+          <div key={`${failure.runId}-${failure.stage}-${idx}`} className="flex flex-col gap-1 rounded-md border p-2.5">
+            <div className="flex items-center gap-2">
+              <Link href={`/?run=${failure.runId}`} className="font-mono text-[11px] text-primary hover:underline">
+                {failure.runId.slice(0, 8)}
+              </Link>
+              <Badge variant="secondary" className="bg-[var(--status-failed-soft)] text-[var(--status-failed)] hover:bg-[var(--status-failed-soft)] text-[10px]">
+                {failure.stage}
+              </Badge>
+              <span className="ml-auto text-[10px] text-muted-foreground">
+                {new Date(failure.failedAt).toLocaleString()}
+              </span>
+            </div>
+            {failure.ticket && (
+              <p className="text-[11px] text-muted-foreground truncate">{failure.ticket}</p>
+            )}
+            {failure.error && (
+              <p className="text-[11px] text-destructive/80 font-mono truncate">{failure.error}</p>
+            )}
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function AnalyticsDashboard() {
+  const { data, loading, error } = useAnalytics();
+
+  return (
+    <div className="flex h-screen flex-col">
+      <header className="flex h-12 items-center border-b bg-card px-3 md:px-4 shrink-0 gap-3">
+        <Button variant="ghost" size="sm" className="h-7 text-xs gap-1" asChild>
+          <Link href="/">
+            <ArrowLeft className="h-3.5 w-3.5" />
+            <span className="hidden sm:inline">Board</span>
+          </Link>
+        </Button>
+        <h1 className="text-sm font-bold tracking-tight">Analytics</h1>
+      </header>
+
+      <main className="flex-1 min-h-0 overflow-y-auto p-3 md:p-4 space-y-4 max-w-5xl mx-auto w-full">
+        {error && (
+          <div className="bg-destructive/10 px-4 py-1.5 text-xs text-destructive rounded-md">
+            {error}
+          </div>
+        )}
+
+        {loading && !data && (
+          <p className="text-sm text-muted-foreground text-center py-8">Loading analytics...</p>
+        )}
+
+        {data && (
+          <>
+            <SummaryCards
+              totalRuns={data.totalRuns}
+              successRate={data.successRate}
+              avgDurationMs={data.avgDurationMs}
+              activeRuns={data.runsByStatus.running}
+            />
+            <StageBreakdownTable stages={data.stages} />
+            <RecentFailuresList failures={data.recentFailures} />
+          </>
+        )}
+
+        {!loading && data && data.totalRuns === 0 && (
+          <p className="text-sm text-muted-foreground text-center py-4">
+            No runs yet. Create a run from the board to see analytics.
+          </p>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/app/analytics/_components/use-analytics.ts
+++ b/app/analytics/_components/use-analytics.ts
@@ -1,0 +1,85 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import type { StageName } from "@/lib/harness/types";
+
+export interface StageMetrics {
+  name: StageName;
+  total: number;
+  success: number;
+  failed: number;
+  skipped: number;
+  avgDurationMs: number | null;
+}
+
+export interface RecentFailure {
+  runId: string;
+  ticket: string;
+  stage: StageName;
+  error: string;
+  failedAt: string;
+}
+
+export interface AnalyticsData {
+  totalRuns: number;
+  runsByStatus: { queued: number; running: number; failed: number; done: number };
+  successRate: number | null;
+  avgDurationMs: number | null;
+  stages: StageMetrics[];
+  recentFailures: RecentFailure[];
+}
+
+const POLL_MS = 10_000;
+
+async function fetchAnalytics(): Promise<AnalyticsData> {
+  const response = await fetch("/api/analytics", { cache: "no-store" });
+  const data = (await response.json()) as AnalyticsData & { error?: string };
+  if (!response.ok) {
+    throw new Error(data.error ?? `request failed: ${response.status}`);
+  }
+  return data;
+}
+
+export function useAnalytics() {
+  const [data, setData] = useState<AnalyticsData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  const refresh = useCallback(async () => {
+    const result = await fetchAnalytics();
+    setData(result);
+  }, []);
+
+  useEffect(() => {
+    let canceled = false;
+
+    fetchAnalytics()
+      .then((result) => {
+        if (!canceled) setData(result);
+      })
+      .catch((err: unknown) => {
+        if (!canceled) setError(err instanceof Error ? err.message : "failed to load analytics");
+      })
+      .finally(() => {
+        if (!canceled) setLoading(false);
+      });
+
+    const timer = setInterval(() => {
+      fetchAnalytics()
+        .then((result) => {
+          if (!canceled) setData(result);
+        })
+        .catch((err: unknown) => {
+          if (!canceled) setError(err instanceof Error ? err.message : "poll failed");
+        });
+    }, POLL_MS);
+
+    return () => {
+      canceled = true;
+      clearInterval(timer);
+    };
+  }, []);
+
+  return { data, loading, error, setError, refresh };
+}

--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -1,0 +1,5 @@
+import { AnalyticsDashboard } from "./_components/analytics-dashboard";
+
+export default function AnalyticsPage() {
+  return <AnalyticsDashboard />;
+}

--- a/app/api/analytics/route.ts
+++ b/app/api/analytics/route.ts
@@ -1,0 +1,121 @@
+import { NextResponse } from "next/server";
+
+import { getOrchestrator } from "@/lib/harness/singleton";
+import { STAGE_ORDER, type RunRecord, type StageName } from "@/lib/harness/types";
+
+export const runtime = "nodejs";
+
+interface StageMetrics {
+  name: StageName;
+  total: number;
+  success: number;
+  failed: number;
+  skipped: number;
+  avgDurationMs: number | null;
+}
+
+interface RecentFailure {
+  runId: string;
+  ticket: string;
+  stage: StageName;
+  error: string;
+  failedAt: string;
+}
+
+interface AnalyticsData {
+  totalRuns: number;
+  runsByStatus: { queued: number; running: number; failed: number; done: number };
+  successRate: number | null;
+  avgDurationMs: number | null;
+  stages: StageMetrics[];
+  recentFailures: RecentFailure[];
+}
+
+function computeDurationMs(startedAt: string | null, endedAt: string | null): number | null {
+  if (!startedAt || !endedAt) return null;
+  const diff = new Date(endedAt).getTime() - new Date(startedAt).getTime();
+  return diff > 0 ? diff : null;
+}
+
+function computeRunDurationMs(run: RunRecord): number | null {
+  if (run.status !== "done" && run.status !== "failed") return null;
+  const firstStarted = run.stages.find((s) => s.startedAt)?.startedAt ?? null;
+  const lastEnded = run.stages
+    .filter((s) => s.endedAt)
+    .sort((a, b) => new Date(b.endedAt!).getTime() - new Date(a.endedAt!).getTime())[0]?.endedAt ?? null;
+  return computeDurationMs(firstStarted, lastEnded);
+}
+
+export async function GET(): Promise<NextResponse> {
+  const orchestrator = getOrchestrator();
+  const runs = await orchestrator.listRuns();
+
+  const runsByStatus = { queued: 0, running: 0, failed: 0, done: 0 };
+  for (const run of runs) {
+    runsByStatus[run.status]++;
+  }
+
+  const completed = runsByStatus.done + runsByStatus.failed;
+  const successRate = completed > 0 ? runsByStatus.done / completed : null;
+
+  const runDurations = runs.map(computeRunDurationMs).filter((d): d is number => d !== null);
+  const avgDurationMs =
+    runDurations.length > 0 ? runDurations.reduce((a, b) => a + b, 0) / runDurations.length : null;
+
+  const stages: StageMetrics[] = STAGE_ORDER.map((stageName) => {
+    let total = 0;
+    let success = 0;
+    let failed = 0;
+    let skipped = 0;
+    const durations: number[] = [];
+
+    for (const run of runs) {
+      const stage = run.stages.find((s) => s.name === stageName);
+      if (!stage || stage.status === "queued") continue;
+      total++;
+      if (stage.status === "done") success++;
+      else if (stage.status === "failed") failed++;
+      else if (stage.status === "skipped") skipped++;
+
+      const dur = computeDurationMs(stage.startedAt, stage.endedAt);
+      if (dur !== null) durations.push(dur);
+    }
+
+    return {
+      name: stageName,
+      total,
+      success,
+      failed,
+      skipped,
+      avgDurationMs: durations.length > 0 ? durations.reduce((a, b) => a + b, 0) / durations.length : null,
+    };
+  });
+
+  const recentFailures: RecentFailure[] = [];
+  const sortedRuns = [...runs].sort((a, b) => (a.updatedAt > b.updatedAt ? -1 : 1));
+  for (const run of sortedRuns) {
+    if (recentFailures.length >= 10) break;
+    for (const stage of run.stages) {
+      if (stage.status === "failed" && recentFailures.length < 10) {
+        recentFailures.push({
+          runId: run.id,
+          ticket: run.ticket,
+          stage: stage.name,
+          error: stage.lastError ? stage.lastError.slice(0, 200) : "",
+          failedAt: stage.endedAt ?? run.updatedAt,
+        });
+      }
+    }
+  }
+
+  const data: AnalyticsData = {
+    totalRuns: runs.length,
+    runsByStatus,
+    successRate,
+    avgDurationMs,
+    stages,
+    recentFailures,
+  };
+
+  return NextResponse.json(data);
+}


### PR DESCRIPTION
## Summary
- Add `/analytics` page with summary cards (total runs, success rate, avg duration, active runs)
- Add stage breakdown table showing per-stage success/failure/skip counts and average durations
- Add recent failures list with clickable run links, stage badges, and error excerpts
- Add `GET /api/analytics` endpoint that computes aggregate metrics from the run store
- Add "Analytics" button to the top bar for navigation

## Test plan
- [x] `pnpm lint` passes (0 new errors)
- [x] `pnpm typecheck` passes clean
- [ ] Verify dashboard renders correctly with existing runs
- [ ] Verify empty state displays when no runs exist
- [ ] Verify Analytics button in top bar navigates to `/analytics`
- [ ] Verify auto-refresh polling updates metrics every 10 seconds