### PR TITLE
Add browser-powered Verify stage with agent-browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A local-first control plane for running AI coding agents through structured SDLC
 ## Features
 
 - **Pipeline templates** — Feature, Bug Fix, Refactor, Docs, and Review workflows with pre-configured stage sequences
-- **Multi-provider support** — Claude, Codex, and Gemini (auto-detected from your local CLI installs), plus a mock mode that works with zero setup
+- **Multi-provider support** — Claude and Codex (auto-detected from your local CLI installs), plus a mock mode that works with zero setup
 - **Kanban board UI** — Runs flow through columns as stages complete, with real-time progress updates
 - **Stage controls** — Retry a stage, retry from a stage, edit the prompt and rerun, or skip with a reason
 - **Stage detail drawer** — View the full prompt, output artifact, streaming logs, and errors for every attempt
@@ -46,7 +46,6 @@ To use actual AI agents instead of mock mode, install and authenticate the CLI f
 |----------|-----|-------|
 | Claude | `claude` | [Install Claude Code](https://docs.anthropic.com/en/docs/claude-code) and sign in |
 | Codex | `codex` | [Install Codex CLI](https://github.com/openai/codex) and authenticate |
-| Gemini | `gemini` | [Install Gemini CLI](https://github.com/google-gemini/gemini-cli) and authenticate |
 
 Code Factory auto-detects which CLIs are available on your system and shows them in the runner mode dropdown when creating a run.
 
@@ -70,7 +69,7 @@ app/
   _hooks/                   # Client hooks (polling, actions, repo CRUD)
 lib/harness/
   orchestrator.ts           # Execution engine — drives stages sequentially
-  providers.ts              # CLI abstraction for Claude, Codex, Gemini
+  providers.ts              # CLI abstraction for Claude and Codex
   pipeline-templates.ts     # Built-in template definitions
   runners.ts                # Stage execution handlers
   prompts.ts                # Prompt template loading and variable rendering

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A local-first control plane for running AI coding agents through structured SDLC
 - **Stage controls** — Retry a stage, retry from a stage, edit the prompt and rerun, or skip with a reason
 - **Stage detail drawer** — View the full prompt, output artifact, streaming logs, and errors for every attempt
 - **Per-stage overrides** — Swap the provider, model, or thinking level for individual stages without changing the run config
+- **Browser-powered Verify** — Feature pipeline Verify stage runs browser validation and captures evidence via `agent-browser`
 - **Repo management** — Register repos with custom setup scripts, test commands, and env file patterns; runs get isolated git worktrees automatically
 - **File-backed persistence** — Everything lives in JSON and flat files. No database, no external services
 
@@ -49,12 +50,23 @@ To use actual AI agents instead of mock mode, install and authenticate the CLI f
 
 Code Factory auto-detects which CLIs are available on your system and shows them in the runner mode dropdown when creating a run.
 
+### Browser Verification (required for browser-enabled templates)
+
+Feature runs use a browser-aware Verify stage and require `agent-browser`:
+
+```bash
+npm install -g agent-browser
+agent-browser install
+```
+
+If `agent-browser` is missing, browser-enabled runs fail fast at creation with setup instructions.
+
 ## Pipeline Templates
 
 | Template | Stages | Use case |
 |----------|--------|----------|
-| **Feature** | Plan → Implement → Verify → Test → PR | Full SDLC for new features |
-| **Bug Fix** | Plan → Implement → Test → PR | Skips verification for faster fixes |
+| **Feature** | Plan → Implement → Verify (browser) → Test → PR → Review | Full SDLC for new features with browser validation |
+| **Bug Fix** | Plan → Implement → Test → PR → Review | Faster fixes with final review |
 | **Refactor** | Plan → Implement → Test | No PR — for internal cleanups |
 | **Docs** | Plan → Implement → PR | Lightweight flow for documentation |
 | **Review** | Plan → Verify | Review-only, no implementation |
@@ -75,7 +87,7 @@ lib/harness/
   prompts.ts                # Prompt template loading and variable rendering
   store.ts                  # JSON file persistence
   workspace-manager.ts      # Git worktree provisioning
-prompt-templates/           # Prompt .txt files for each stage (plan, implement, verify, test, pr)
+prompt-templates/           # Stage prompt contracts and templates (including verify-browser)
 runs/                       # Created at runtime — attempt artifacts, logs, and progress files
 .data/                      # Created at runtime — store.json
 ```

--- a/app/_components/new-run-dialog.tsx
+++ b/app/_components/new-run-dialog.tsx
@@ -22,8 +22,19 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
-import { BUILTIN_TEMPLATES, DEFAULT_TEMPLATE_ID } from "@/lib/harness/pipeline-templates";
-import type { PrMode, ProviderData, RepoConfig, RunRecord, RunnerMode } from "@/lib/harness/types";
+import {
+  BUILTIN_TEMPLATES,
+  DEFAULT_TEMPLATE_ID,
+  templateRequiresAgentBrowser,
+} from "@/lib/harness/pipeline-templates";
+import type {
+  PrMode,
+  ProviderData,
+  RepoConfig,
+  RunRecord,
+  RunnerMode,
+  RuntimeCapabilitiesData,
+} from "@/lib/harness/types";
 
 import type { DirectoryBrowseResponse, DirectoryEntry } from "../_hooks/use-run-actions";
 
@@ -64,6 +75,7 @@ export function NewRunDialog({
   const [prMode, setPrMode] = useState<PrMode>("simulate");
   const [templateId, setTemplateId] = useState(DEFAULT_TEMPLATE_ID);
   const [providers, setProviders] = useState<ProviderData[]>([]);
+  const [capabilities, setCapabilities] = useState<RuntimeCapabilitiesData | null>(null);
 
   const [showPicker, setShowPicker] = useState(false);
   const [pickerLoading, setPickerLoading] = useState(false);
@@ -78,8 +90,9 @@ export function NewRunDialog({
     if (!open) return;
     void fetch("/api/providers")
       .then((res) => res.json())
-      .then((data: { providers: ProviderData[] }) => {
+      .then((data: { providers: ProviderData[]; capabilities?: RuntimeCapabilitiesData }) => {
         setProviders(data.providers ?? []);
+        setCapabilities(data.capabilities ?? null);
       })
       .catch(() => {});
   }, [open]);
@@ -116,6 +129,11 @@ export function NewRunDialog({
   };
 
   const selectedTemplate = BUILTIN_TEMPLATES.find((t) => t.id === templateId);
+  const selectedTemplateRequiresAgentBrowser = selectedTemplate
+    ? templateRequiresAgentBrowser(selectedTemplate)
+    : false;
+  const agentBrowser = capabilities?.agentBrowser ?? null;
+  const isBlockedByMissingAgentBrowser = selectedTemplateRequiresAgentBrowser && !agentBrowser?.available;
 
   const loadDirectory = useCallback(
     async (targetPath: string) => {
@@ -327,6 +345,19 @@ export function NewRunDialog({
               {selectedTemplate && (
                 <p className="text-[11px] text-muted-foreground">{selectedTemplate.description}</p>
               )}
+              {selectedTemplateRequiresAgentBrowser && (
+                <div className={`rounded-md border px-2 py-1.5 text-[11px] ${isBlockedByMissingAgentBrowser ? "border-destructive/40 bg-destructive/10 text-destructive" : "border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400"}`}>
+                  {isBlockedByMissingAgentBrowser ? (
+                    <>
+                      <p className="font-medium">Browser verification requires `agent-browser`.</p>
+                      <p className="mt-0.5 font-mono">Install: {agentBrowser?.installCommand ?? "npm install -g agent-browser"}</p>
+                      <p className="font-mono">Setup: {agentBrowser?.setupCommand ?? "agent-browser install"}</p>
+                    </>
+                  ) : (
+                    <p className="font-medium">`agent-browser` detected. Browser Verify is enabled for this template.</p>
+                  )}
+                </div>
+              )}
             </div>
 
             <div className="flex flex-col gap-1.5">
@@ -452,7 +483,7 @@ export function NewRunDialog({
             <Button variant="outline" onClick={onClose}>
               Cancel
             </Button>
-            <Button disabled={loading || !ticket.trim()} onClick={handleSubmit}>
+            <Button disabled={loading || !ticket.trim() || isBlockedByMissingAgentBrowser} onClick={handleSubmit}>
               Create + Start
             </Button>
           </DialogFooter>

--- a/app/_components/repo-management-dialog.tsx
+++ b/app/_components/repo-management-dialog.tsx
@@ -41,6 +41,9 @@ export function RepoManagementDialog({
     setupScript?: string;
     envFiles?: string[];
     defaultTestCommand?: string;
+    appBaseUrl?: string;
+    appStartCommand?: string;
+    appReadyPattern?: string;
   }) => Promise<RepoConfig | null>;
   onUpdateRepo: (
     repoId: string,
@@ -49,6 +52,9 @@ export function RepoManagementDialog({
       setupScript?: string;
       envFiles?: string[];
       defaultTestCommand?: string;
+      appBaseUrl?: string;
+      appStartCommand?: string;
+      appReadyPattern?: string;
     },
   ) => Promise<RepoConfig | null>;
   onDeleteRepo: (repoId: string) => Promise<boolean>;
@@ -64,6 +70,9 @@ export function RepoManagementDialog({
   const [setupScript, setSetupScript] = useState("");
   const [envFiles, setEnvFiles] = useState("");
   const [defaultTestCommand, setDefaultTestCommand] = useState("pnpm lint");
+  const [appBaseUrl, setAppBaseUrl] = useState("http://127.0.0.1:3000");
+  const [appStartCommand, setAppStartCommand] = useState("pnpm dev");
+  const [appReadyPattern, setAppReadyPattern] = useState("ready");
 
   // Picker state
   const [showPicker, setShowPicker] = useState(false);
@@ -80,6 +89,9 @@ export function RepoManagementDialog({
     setSetupScript("");
     setEnvFiles("");
     setDefaultTestCommand("pnpm lint");
+    setAppBaseUrl("http://127.0.0.1:3000");
+    setAppStartCommand("pnpm dev");
+    setAppReadyPattern("ready");
     setEditingRepo(null);
     setShowPicker(false);
   };
@@ -95,6 +107,9 @@ export function RepoManagementDialog({
     setSetupScript(repo.setupScript);
     setEnvFiles(repo.envFiles.join(", "));
     setDefaultTestCommand(repo.defaultTestCommand);
+    setAppBaseUrl(repo.appBaseUrl || "http://127.0.0.1:3000");
+    setAppStartCommand(repo.appStartCommand || "pnpm dev");
+    setAppReadyPattern(repo.appReadyPattern || "ready");
     setView("edit");
   };
 
@@ -135,6 +150,9 @@ export function RepoManagementDialog({
       setupScript: setupScript.trim() || undefined,
       envFiles: envFileList.length > 0 ? envFileList : undefined,
       defaultTestCommand: defaultTestCommand.trim() || undefined,
+      appBaseUrl: appBaseUrl.trim() || undefined,
+      appStartCommand: appStartCommand.trim() || undefined,
+      appReadyPattern: appReadyPattern.trim() || undefined,
     });
     setSaving(false);
     if (result) {
@@ -154,6 +172,9 @@ export function RepoManagementDialog({
       setupScript: setupScript.trim(),
       envFiles: envFileList,
       defaultTestCommand: defaultTestCommand.trim(),
+      appBaseUrl: appBaseUrl.trim(),
+      appStartCommand: appStartCommand.trim(),
+      appReadyPattern: appReadyPattern.trim(),
     });
     setSaving(false);
     if (result) {
@@ -365,6 +386,40 @@ export function RepoManagementDialog({
                     value={defaultTestCommand}
                     onChange={(e) => setDefaultTestCommand(e.target.value)}
                   />
+                </div>
+
+                <div className="flex flex-col gap-1.5">
+                  <label className="text-xs font-medium">App Base URL</label>
+                  <Input
+                    className="text-sm font-mono"
+                    placeholder="http://127.0.0.1:3000"
+                    value={appBaseUrl}
+                    onChange={(e) => setAppBaseUrl(e.target.value)}
+                  />
+                  <p className="text-[10px] text-muted-foreground">
+                    Used by browser verification prompts as the default app URL.
+                  </p>
+                </div>
+
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                  <div className="flex flex-col gap-1.5">
+                    <label className="text-xs font-medium">App Start Command</label>
+                    <Input
+                      className="text-sm font-mono"
+                      placeholder="pnpm dev"
+                      value={appStartCommand}
+                      onChange={(e) => setAppStartCommand(e.target.value)}
+                    />
+                  </div>
+                  <div className="flex flex-col gap-1.5">
+                    <label className="text-xs font-medium">App Ready Pattern</label>
+                    <Input
+                      className="text-sm font-mono"
+                      placeholder="ready"
+                      value={appReadyPattern}
+                      onChange={(e) => setAppReadyPattern(e.target.value)}
+                    />
+                  </div>
                 </div>
               </div>
             )}

--- a/app/_components/stage-detail.tsx
+++ b/app/_components/stage-detail.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Check, ChevronDown, Clock, Copy } from "lucide-react";
+import { Check, ChevronDown, Clock, Copy, ImageOff } from "lucide-react";
+import Image from "next/image";
 
 import { ExternalLink } from "lucide-react";
 
@@ -627,11 +628,130 @@ function extractPrUrl(stage: StageRun, prUrl?: string | null): string | null {
   return match?.[0] ?? null;
 }
 
+interface EvidenceEntry {
+  path: string;
+  note: string;
+}
+
+function parseEvidenceEntries(output: string): EvidenceEntry[] {
+  if (!output) return [];
+  const entries: EvidenceEntry[] = [];
+  const seen = new Set<string>();
+
+  for (const rawLine of output.split("\n")) {
+    const line = rawLine.trim();
+    const marker = "EVIDENCE_PATH:";
+    const idx = line.indexOf(marker);
+    if (idx === -1) continue;
+
+    const content = line.slice(idx + marker.length).trim();
+    if (!content) continue;
+
+    const delimiterIdx = content.indexOf(" -- ");
+    const evidencePath = delimiterIdx === -1 ? content : content.slice(0, delimiterIdx).trim();
+    const note = delimiterIdx === -1 ? "" : content.slice(delimiterIdx + 4).trim();
+
+    if (!evidencePath || seen.has(evidencePath)) continue;
+    seen.add(evidencePath);
+    entries.push({ path: evidencePath, note });
+  }
+
+  return entries;
+}
+
+function evidenceName(evidencePath: string): string {
+  const normalized = evidencePath.replace(/\\/g, "/");
+  const last = normalized.split("/").at(-1);
+  return last && last.length > 0 ? last : evidencePath;
+}
+
+function resolveEvidencePath(evidencePath: string, attemptLogPath: string | null | undefined): string {
+  const trimmed = evidencePath.trim();
+  if (!trimmed) return trimmed;
+
+  // Absolute Unix, Windows drive, or UNC path
+  if (
+    trimmed.startsWith("/") ||
+    /^[A-Za-z]:[\\/]/.test(trimmed) ||
+    trimmed.startsWith("\\\\")
+  ) {
+    return trimmed;
+  }
+
+  if (!attemptLogPath) return trimmed;
+
+  const normalizedLogPath = attemptLogPath.replace(/\\/g, "/");
+  const baseDir = normalizedLogPath.endsWith(".txt")
+    ? normalizedLogPath.slice(0, normalizedLogPath.lastIndexOf("/"))
+    : normalizedLogPath;
+  const cleanBase = baseDir.replace(/\/+$/, "");
+  const cleanPath = trimmed.replace(/^\.?\//, "");
+  return `${cleanBase}/${cleanPath}`;
+}
+
+function EvidenceThumbnail({
+  runId,
+  evidencePath,
+  note,
+}: {
+  runId: string;
+  evidencePath: string;
+  note: string;
+}) {
+  const [loadFailed, setLoadFailed] = useState(false);
+  const missingFromNote = /not captured/i.test(note);
+  const evidenceUrl = `/api/runs/${encodeURIComponent(runId)}/evidence?path=${encodeURIComponent(evidencePath)}`;
+  const missing = loadFailed || missingFromNote;
+
+  return (
+    <a
+      href={missing ? undefined : evidenceUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="group rounded-md border overflow-hidden bg-background hover:border-primary/40 transition-colors"
+      title={evidencePath}
+      onClick={(event) => {
+        if (missing) event.preventDefault();
+      }}
+    >
+      {missing ? (
+        <div className="flex h-28 w-full items-center justify-center bg-muted text-muted-foreground">
+          <div className="flex flex-col items-center gap-1 text-[10px]">
+            <ImageOff className="h-4 w-4" />
+            <span>screenshot missing</span>
+          </div>
+        </div>
+      ) : (
+        <Image
+          src={evidenceUrl}
+          alt={note || evidenceName(evidencePath)}
+          width={640}
+          height={360}
+          unoptimized
+          className="block w-full h-28 object-cover bg-muted"
+          loading="lazy"
+          onError={() => setLoadFailed(true)}
+        />
+      )}
+      <div className="px-2 py-1.5">
+        <p className="text-[10px] font-mono truncate">{evidenceName(evidencePath)}</p>
+        {note && (
+          <p className="text-[10px] text-muted-foreground line-clamp-2">{note}</p>
+        )}
+      </div>
+    </a>
+  );
+}
+
 export function StageDetail({ stage, runId, prUrl }: { stage: StageRun; runId: string; prUrl?: string | null }) {
   const [selectedAttemptIdx, setSelectedAttemptIdx] = useState<number | null>(null);
   const latest = stage.attempts.at(-1) ?? null;
   const viewing = selectedAttemptIdx !== null ? stage.attempts[selectedAttemptIdx] ?? latest : latest;
   const detectedPrUrl = extractPrUrl(stage, prUrl);
+  const evidenceEntries = useMemo(
+    () => parseEvidenceEntries(viewing?.outputPreview || ""),
+    [viewing?.outputPreview],
+  );
 
   return (
     <div className="flex flex-col gap-3 py-3">
@@ -684,6 +804,25 @@ export function StageDetail({ stage, runId, prUrl }: { stage: StageRun; runId: s
 
       {/* content sections — show selected attempt's data */}
       <div className="flex flex-col gap-1.5">
+        {evidenceEntries.length > 0 && (
+          <div className="rounded-md border bg-muted/20 p-3">
+            <p className="text-xs font-semibold mb-2">Evidence</p>
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
+              {evidenceEntries.map((entry) => {
+                const resolvedEvidencePath = resolveEvidencePath(entry.path, viewing?.logPath);
+                return (
+                  <EvidenceThumbnail
+                    key={entry.path}
+                    runId={runId}
+                    evidencePath={resolvedEvidencePath}
+                    note={entry.note}
+                  />
+                );
+              })}
+            </div>
+          </div>
+        )}
+
         <CollapsibleSection
           title="Prompt"
           defaultOpen={false}

--- a/app/_components/stage-detail.tsx
+++ b/app/_components/stage-detail.tsx
@@ -10,7 +10,7 @@ import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Separator } from "@/components/ui/separator";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import type { StageRun } from "@/lib/harness/types";
+import type { StageAttempt, StageRun } from "@/lib/harness/types";
 import { cn } from "@/lib/utils";
 
 import { StatusBadge } from "./status-badge";
@@ -196,8 +196,32 @@ interface StreamEvent {
   item?: Record<string, unknown>;
 }
 
-function parseLogEntries(rawContent: string): LogEntry[] {
-  const lines = rawContent.split("\n").filter((l) => l.trim());
+// ---------------------------------------------------------------------------
+// Format detection + branched parsers
+// ---------------------------------------------------------------------------
+
+type StreamFormat = "claude" | "codex";
+
+function detectStreamFormat(lines: string[]): StreamFormat {
+  for (const line of lines) {
+    try {
+      const event = JSON.parse(line) as Record<string, unknown>;
+      // Codex signature: thread.started or any event with thread_id
+      if (event.type === "thread.started" || "thread_id" in event) return "codex";
+      // Codex item envelope events
+      if (event.type === "item.started" || event.type === "item.completed" || event.type === "item.updated") return "codex";
+      if (event.type === "turn.started" || event.type === "turn.completed" || event.type === "turn.failed") return "codex";
+      // Claude signature: system init or assistant with message.content
+      if (event.type === "system" || event.type === "result") return "claude";
+      if (event.type === "assistant" || event.type === "user") return "claude";
+    } catch {
+      // skip non-JSON lines
+    }
+  }
+  return "claude"; // safe default
+}
+
+function parseClaudeLogEntries(lines: string[]): LogEntry[] {
   const entries: LogEntry[] = [];
   const toolMap = new Map<string, LogEntry & { kind: "tool" }>();
 
@@ -206,12 +230,10 @@ function parseLogEntries(rawContent: string): LogEntry[] {
     try {
       event = JSON.parse(line) as StreamEvent;
     } catch {
-      // Non-JSON line — show raw
       entries.push({ kind: "raw", text: line });
       continue;
     }
 
-    // --- Claude / Gemini stream-json format ---
     if (event.type === "system") {
       let label = "";
       if (event.subtype === "init") {
@@ -267,22 +289,83 @@ function parseLogEntries(rawContent: string): LogEntry[] {
             parent.resultPreview = preview || null;
             parent.resultTotalLines = totalLines;
           }
-          // Don't push a new entry — result folds into existing tool entry
         }
       }
       continue;
     }
 
-    // --- Codex JSONL format (newer: item envelope) ---
-    if (event.item) {
+    // Unknown Claude event — skip
+  }
+
+  return entries;
+}
+
+interface CodexStreamEvent {
+  type?: string;
+  thread_id?: string;
+  message?: string;
+  content?: string;
+  text?: string;
+  usage?: {
+    input_tokens?: number;
+    cached_input_tokens?: number;
+    output_tokens?: number;
+  };
+  item?: {
+    type?: string;
+    text?: string;
+    content?: string;
+    message?: string;
+    command?: string;
+    aggregated_output?: string;
+    exit_code?: number | null;
+    status?: string;
+  };
+}
+
+function parseCodexLogEntries(lines: string[]): LogEntry[] {
+  const entries: LogEntry[] = [];
+
+  for (const line of lines) {
+    let event: CodexStreamEvent;
+    try {
+      event = JSON.parse(line) as CodexStreamEvent;
+    } catch {
+      entries.push({ kind: "raw", text: line });
+      continue;
+    }
+
+    // Lifecycle events
+    if (event.type === "thread.started") {
+      entries.push({ kind: "system", label: "codex session started" });
+      continue;
+    }
+    if (event.type === "turn.started") {
+      // subtle indicator, skip to reduce noise
+      continue;
+    }
+    if (event.type === "turn.completed") {
+      const tokens = event.usage;
+      const parts: string[] = ["completed"];
+      if (tokens?.input_tokens) parts.push(`${tokens.input_tokens} in`);
+      if (tokens?.output_tokens) parts.push(`${tokens.output_tokens} out`);
+      entries.push({ kind: "result", label: parts.join(" · ") });
+      continue;
+    }
+    if (event.type === "turn.failed") {
+      entries.push({ kind: "system", label: `error: ${event.message || "turn failed"}` });
+      continue;
+    }
+
+    // Item events — only process item.completed to avoid duplicates
+    if (event.type === "item.completed" && event.item) {
       const item = event.item;
       if (item.type === "agent_message" && typeof item.text === "string") {
-        entries.push({ kind: "text", preview: truncate(item.text as string, 200) });
+        entries.push({ kind: "text", preview: truncate(item.text, 200) });
       } else if (item.type === "command_execution" && typeof item.command === "string") {
-        const cmd = item.command as string;
-        const output = typeof item.aggregated_output === "string" ? (item.aggregated_output as string) : "";
-        const isDone = item.status === "completed";
-        const exitInfo = isDone ? ` → exit ${item.exit_code ?? "?"}` : "";
+        const cmd = item.command;
+        const output = typeof item.aggregated_output === "string" ? item.aggregated_output : "";
+        const exitInfo = ` → exit ${item.exit_code ?? "?"}`;
         const { preview, totalLines } = extractResultPreview(output);
         entries.push({
           kind: "tool",
@@ -291,24 +374,39 @@ function parseLogEntries(rawContent: string): LogEntry[] {
           param: truncate(cmd, 60) + exitInfo,
           resultPreview: preview || null,
           resultTotalLines: totalLines,
-          status: isDone ? (item.exit_code === 0 ? "done" : "error") : "pending",
+          status: item.exit_code === 0 ? "done" : "error",
+        });
+      } else if (item.type === "file_change") {
+        entries.push({
+          kind: "tool",
+          id: `codex-${entries.length}`,
+          name: "FileChange",
+          param: typeof item.command === "string" ? truncate(item.command, 60) : "",
+          resultPreview: null,
+          resultTotalLines: 0,
+          status: "done",
         });
       } else if (item.type === "error") {
         entries.push({
           kind: "system",
-          label: `error: ${(item.message as string) || (item.text as string) || "unknown error"}`,
+          label: `error: ${item.message || item.text || "unknown error"}`,
         });
       }
       // skip reasoning blocks
       continue;
     }
 
-    // --- Codex JSONL format (legacy) ---
+    // Skip item.started / item.updated to prevent duplicates
+    if (event.type === "item.started" || event.type === "item.updated") {
+      continue;
+    }
+
+    // Legacy Codex format fallback
     if (event.type === "message" && typeof event.content === "string") {
       entries.push({ kind: "text", preview: truncate(event.content, 200) });
       continue;
     }
-    if (event.type === "text" && event.text) {
+    if (event.type === "text" && typeof event.text === "string") {
       entries.push({ kind: "text", preview: truncate(event.text, 200) });
       continue;
     }
@@ -318,10 +416,22 @@ function parseLogEntries(rawContent: string): LogEntry[] {
       continue;
     }
 
-    // Unknown JSON event — skip
+    // Unknown Codex event — skip
   }
 
   return entries;
+}
+
+function parseLogEntries(rawContent: string): LogEntry[] {
+  const lines = rawContent.split("\n").filter((l) => l.trim());
+  if (lines.length === 0) return [];
+
+  const format = detectStreamFormat(lines);
+
+  if (format === "codex") {
+    return parseCodexLogEntries(lines);
+  }
+  return parseClaudeLogEntries(lines);
 }
 
 // ---------------------------------------------------------------------------
@@ -382,7 +492,31 @@ function LogEntryRow({ entry }: { entry: LogEntry }) {
 // LiveOutput component
 // ---------------------------------------------------------------------------
 
-function LiveOutput({ runId, stageName, active }: { runId: string; stageName: string; active: boolean }) {
+function formatProviderLabel(attempt: StageAttempt | null): string {
+  if (!attempt?.providerUsed) return "provider";
+  const provider = attempt.providerUsed;
+  const model = attempt.modelUsed;
+  if (model) return `${provider}/${model}`;
+  return provider;
+}
+
+function formatAttemptMeta(attempt: StageAttempt): string {
+  const parts: string[] = [];
+  if (attempt.providerUsed) {
+    parts.push(attempt.providerUsed.charAt(0).toUpperCase() + attempt.providerUsed.slice(1));
+    if (attempt.modelUsed) parts[parts.length - 1] += ` ${attempt.modelUsed}`;
+  }
+  if (attempt.costUsd != null) parts.push(`$${attempt.costUsd.toFixed(3)}`);
+  if (attempt.inputTokens != null || attempt.outputTokens != null) {
+    const tok: string[] = [];
+    if (attempt.inputTokens != null) tok.push(`${attempt.inputTokens} in`);
+    if (attempt.outputTokens != null) tok.push(`${attempt.outputTokens} out`);
+    parts.push(tok.join("/"));
+  }
+  return parts.length > 0 ? ` — ${parts.join(" · ")}` : "";
+}
+
+function LiveOutput({ runId, stageName, active, providerLabel }: { runId: string; stageName: string; active: boolean; providerLabel: string }) {
   const [content, setContent] = useState("");
   const scrollRef = useRef<HTMLDivElement>(null);
   const hasFetchedOnce = useRef(false);
@@ -458,7 +592,7 @@ function LiveOutput({ runId, stageName, active }: { runId: string; stageName: st
               ? entries.map((entry, i) => <LogEntryRow key={i} entry={entry} />)
               : active && (
                   <span className="text-xs text-green-400/60">
-                    Waiting for Claude to start streaming...
+                    Waiting for {providerLabel} to start streaming...
                   </span>
                 )}
           </div>
@@ -529,7 +663,7 @@ export function StageDetail({ stage, runId, prUrl }: { stage: StageRun; runId: s
             >
               {stage.attempts.map((a, i) => (
                 <option key={a.attempt} value={i}>
-                  Attempt {a.attempt}{a.cycle ? ` (cycle ${a.cycle})` : ""}{i === stage.attempts.length - 1 ? " (latest)" : ""}
+                  Attempt {a.attempt}{a.cycle ? ` (cycle ${a.cycle})` : ""}{formatAttemptMeta(a)}{i === stage.attempts.length - 1 ? " (latest)" : ""}
                 </option>
               ))}
             </select>
@@ -545,7 +679,7 @@ export function StageDetail({ stage, runId, prUrl }: { stage: StageRun; runId: s
 
       {/* stream log — live when running, static when complete */}
       {stage.attempts.length > 0 && (
-        <LiveOutput runId={runId} stageName={stage.name} active={stage.status === "running"} />
+        <LiveOutput runId={runId} stageName={stage.name} active={stage.status === "running"} providerLabel={formatProviderLabel(latest)} />
       )}
 
       {/* content sections — show selected attempt's data */}
@@ -623,13 +757,19 @@ export function StageDetail({ stage, runId, prUrl }: { stage: StageRun; runId: s
                     </div>
                     <StatusBadge status={attempt.status} />
                   </div>
-                  <div className="flex items-center gap-4 text-muted-foreground">
+                  <div className="flex items-center gap-4 text-muted-foreground flex-wrap">
                     <span>{displayDate(attempt.startedAt)}</span>
                     {attempt.endedAt && (
                       <span className="inline-flex items-center gap-1">
                         <Clock className="h-3 w-3" />
                         {elapsed(attempt.startedAt, attempt.endedAt)}
                       </span>
+                    )}
+                    {attempt.providerUsed && (
+                      <span>{attempt.providerUsed}{attempt.modelUsed ? `/${attempt.modelUsed}` : ""}</span>
+                    )}
+                    {attempt.costUsd != null && (
+                      <span>${attempt.costUsd.toFixed(3)}</span>
                     )}
                   </div>
                 </button>

--- a/app/_hooks/use-repos.ts
+++ b/app/_hooks/use-repos.ts
@@ -85,6 +85,9 @@ export function useRepos() {
       setupScript?: string;
       envFiles?: string[];
       defaultTestCommand?: string;
+      appBaseUrl?: string;
+      appStartCommand?: string;
+      appReadyPattern?: string;
     }): Promise<RepoConfig | null> => {
       try {
         setError("");
@@ -107,6 +110,9 @@ export function useRepos() {
         setupScript?: string;
         envFiles?: string[];
         defaultTestCommand?: string;
+        appBaseUrl?: string;
+        appStartCommand?: string;
+        appReadyPattern?: string;
       },
     ): Promise<RepoConfig | null> => {
       try {

--- a/app/api/providers/route.ts
+++ b/app/api/providers/route.ts
@@ -1,11 +1,14 @@
 import { NextResponse } from "next/server";
 
-import { getAvailableProviders } from "@/lib/harness/singleton";
+import { getAvailableProviders, getRuntimeCapabilities } from "@/lib/harness/singleton";
 
 export const runtime = "nodejs";
 
 export async function GET(): Promise<NextResponse> {
-  const providers = await getAvailableProviders();
+  const [providers, capabilities] = await Promise.all([
+    getAvailableProviders(),
+    getRuntimeCapabilities(),
+  ]);
   return NextResponse.json({
     providers: providers.map((p) => ({
       id: p.id,
@@ -18,5 +21,6 @@ export async function GET(): Promise<NextResponse> {
         thinkingLevels: m.thinkingLevels,
       })),
     })),
+    capabilities,
   });
 }

--- a/app/api/repos/[repoId]/route.ts
+++ b/app/api/repos/[repoId]/route.ts
@@ -23,6 +23,9 @@ interface UpdateRepoPayload {
   setupScript?: string;
   envFiles?: string[];
   defaultTestCommand?: string;
+  appBaseUrl?: string;
+  appStartCommand?: string;
+  appReadyPattern?: string;
 }
 
 export async function PUT(request: NextRequest, { params }: RouteParams): Promise<NextResponse> {
@@ -38,6 +41,9 @@ export async function PUT(request: NextRequest, { params }: RouteParams): Promis
   if (payload.setupScript !== undefined) repo.setupScript = payload.setupScript.trim();
   if (payload.envFiles !== undefined) repo.envFiles = payload.envFiles;
   if (payload.defaultTestCommand !== undefined) repo.defaultTestCommand = payload.defaultTestCommand.trim();
+  if (payload.appBaseUrl !== undefined) repo.appBaseUrl = payload.appBaseUrl.trim();
+  if (payload.appStartCommand !== undefined) repo.appStartCommand = payload.appStartCommand.trim();
+  if (payload.appReadyPattern !== undefined) repo.appReadyPattern = payload.appReadyPattern.trim();
   repo.updatedAt = new Date().toISOString();
 
   const updated = await orchestrator.saveRepo(repo);

--- a/app/api/repos/route.ts
+++ b/app/api/repos/route.ts
@@ -11,6 +11,9 @@ interface CreateRepoPayload {
   setupScript?: string;
   envFiles?: string[];
   defaultTestCommand?: string;
+  appBaseUrl?: string;
+  appStartCommand?: string;
+  appReadyPattern?: string;
 }
 
 export async function GET(): Promise<NextResponse> {
@@ -40,6 +43,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     setupScript: payload.setupScript?.trim() ?? "",
     envFiles: payload.envFiles ?? [],
     defaultTestCommand: payload.defaultTestCommand?.trim() ?? "pnpm lint",
+    appBaseUrl: payload.appBaseUrl?.trim() || "http://127.0.0.1:3000",
+    appStartCommand: payload.appStartCommand?.trim() || "pnpm dev",
+    appReadyPattern: payload.appReadyPattern?.trim() || "ready",
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
   });

--- a/app/api/runs/[runId]/evidence/route.ts
+++ b/app/api/runs/[runId]/evidence/route.ts
@@ -1,0 +1,62 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import { NextResponse } from "next/server";
+
+import { getOrchestrator } from "@/lib/harness/singleton";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+interface RouteParams {
+  params: Promise<{ runId: string }>;
+}
+
+function contentTypeFor(filePath: string): string {
+  const ext = path.extname(filePath).toLowerCase();
+  if (ext === ".png") return "image/png";
+  if (ext === ".jpg" || ext === ".jpeg") return "image/jpeg";
+  if (ext === ".webp") return "image/webp";
+  if (ext === ".gif") return "image/gif";
+  if (ext === ".svg") return "image/svg+xml";
+  return "application/octet-stream";
+}
+
+function isWithin(parentDir: string, filePath: string): boolean {
+  const relative = path.relative(parentDir, filePath);
+  return relative !== "" && !relative.startsWith("..") && !path.isAbsolute(relative);
+}
+
+export async function GET(request: Request, { params }: RouteParams): Promise<NextResponse> {
+  const { runId } = await params;
+  const orchestrator = getOrchestrator();
+  const run = await orchestrator.getRun(runId);
+  if (!run) {
+    return NextResponse.json({ error: "run not found" }, { status: 404 });
+  }
+
+  const url = new URL(request.url);
+  const rawPath = (url.searchParams.get("path") ?? "").trim();
+  if (!rawPath) {
+    return NextResponse.json({ error: "path is required" }, { status: 400 });
+  }
+
+  const runRoot = path.resolve(path.join(process.cwd(), "runs", runId));
+  const targetPath = path.resolve(path.isAbsolute(rawPath) ? rawPath : path.join(runRoot, rawPath));
+
+  if (!isWithin(runRoot, targetPath)) {
+    return NextResponse.json({ error: "invalid evidence path" }, { status: 403 });
+  }
+
+  try {
+    const bytes = await readFile(targetPath);
+    return new NextResponse(bytes, {
+      headers: {
+        "content-type": contentTypeFor(targetPath),
+        "cache-control": "no-store",
+      },
+    });
+  } catch {
+    return NextResponse.json({ error: "evidence not found" }, { status: 404 });
+  }
+}

--- a/app/api/runs/route.ts
+++ b/app/api/runs/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { getTemplate } from "@/lib/harness/pipeline-templates";
-import { getOrchestrator, getAvailableProviders } from "@/lib/harness/singleton";
+import { getTemplate, getTemplateOrDefault, templateRequiresAgentBrowser } from "@/lib/harness/pipeline-templates";
+import { getOrchestrator, getAvailableProviders, getRuntimeCapabilities } from "@/lib/harness/singleton";
 import { DEFAULT_STAGE_ORDER, type PrMode, type RunnerMode, type StageOverrides } from "@/lib/harness/types";
 
 export const runtime = "nodejs";
@@ -56,25 +56,50 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: "invalid templateId" }, { status: 400 });
   }
 
-  const orchestrator = getOrchestrator();
-  const run = await orchestrator.createRun({
-    ticket: payload.ticket.trim(),
-    repoPath: payload.repoPath?.trim() || ".",
-    repoId: payload.repoId?.trim() || undefined,
-    runnerMode,
-    testCommand: payload.testCommand?.trim() || "pnpm lint",
-    prMode,
-    templateId: payload.templateId,
-    model: payload.model?.trim() || undefined,
-    thinkingLevel: payload.thinkingLevel?.trim() || undefined,
-    stageOverrides: payload.stageOverrides,
-  });
+  const template = getTemplateOrDefault(payload.templateId);
+  if (templateRequiresAgentBrowser(template)) {
+    const capabilities = await getRuntimeCapabilities();
+    if (!capabilities.agentBrowser.available) {
+      return NextResponse.json(
+        {
+          error: [
+            `template '${template.id}' requires agent-browser, but it is not installed.`,
+            `Install: ${capabilities.agentBrowser.installCommand}`,
+            `Setup: ${capabilities.agentBrowser.setupCommand}`,
+          ].join(" "),
+          capabilities,
+        },
+        { status: 400 },
+      );
+    }
+  }
 
-  return NextResponse.json(
-    {
-      run,
-      template: DEFAULT_STAGE_ORDER,
-    },
-    { status: 201 },
-  );
+  const orchestrator = getOrchestrator();
+  try {
+    const run = await orchestrator.createRun({
+      ticket: payload.ticket.trim(),
+      repoPath: payload.repoPath?.trim() || ".",
+      repoId: payload.repoId?.trim() || undefined,
+      runnerMode,
+      testCommand: payload.testCommand?.trim() || "pnpm lint",
+      prMode,
+      templateId: payload.templateId,
+      model: payload.model?.trim() || undefined,
+      thinkingLevel: payload.thinkingLevel?.trim() || undefined,
+      stageOverrides: payload.stageOverrides,
+    });
+
+    return NextResponse.json(
+      {
+        run,
+        template: DEFAULT_STAGE_ORDER,
+      },
+      { status: 201 },
+    );
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "failed to create run" },
+      { status: 400 },
+    );
+  }
 }

--- a/lib/harness/capabilities.ts
+++ b/lib/harness/capabilities.ts
@@ -1,0 +1,25 @@
+import { spawn } from "node:child_process";
+
+import type { RuntimeCapabilitiesData } from "@/lib/harness/types";
+
+function whichBinary(binary: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const child = spawn("which", [binary], { stdio: "ignore" });
+    child.on("error", () => resolve(false));
+    child.on("close", (code) => resolve(code === 0));
+  });
+}
+
+export async function detectRuntimeCapabilities(): Promise<RuntimeCapabilitiesData> {
+  const agentBrowserBinary = "agent-browser";
+  const agentBrowserAvailable = await whichBinary(agentBrowserBinary);
+
+  return {
+    agentBrowser: {
+      available: agentBrowserAvailable,
+      binary: agentBrowserBinary,
+      installCommand: "npm install -g agent-browser",
+      setupCommand: "agent-browser install",
+    },
+  };
+}

--- a/lib/harness/orchestrator.ts
+++ b/lib/harness/orchestrator.ts
@@ -442,6 +442,12 @@ export class HarnessOrchestrator {
           outputPreview: "",
           logsPreview: "",
           error: "",
+          costUsd: null,
+          inputTokens: null,
+          outputTokens: null,
+          durationMs: null,
+          providerUsed: null,
+          modelUsed: null,
         };
         next.status = "running";
         next.startedAt = nowIso();
@@ -458,9 +464,9 @@ export class HarnessOrchestrator {
         });
         await this.store.saveRun(run);
 
-        const result = await this.executeStage(run, next.name, prompt, attemptDir);
-        await this.applyStageResult(runId, next.name, result);
-        if (!result.success) {
+        const stageResult = await this.executeStage(run, next.name, prompt, attemptDir);
+        await this.applyStageResult(runId, next.name, stageResult.result, stageResult.providerUsed, stageResult.modelUsed);
+        if (!stageResult.result.success) {
           const reverted = await this.tryAutoRevert(runId, next.name);
           if (reverted) continue;
           return;
@@ -635,7 +641,12 @@ export class HarnessOrchestrator {
     return true;
   }
 
-  private async executeStage(run: RunRecord, stageName: string, prompt: string, logDir?: string): Promise<RunnerResult> {
+  private async executeStage(
+    run: RunRecord,
+    stageName: string,
+    prompt: string,
+    logDir?: string,
+  ): Promise<{ result: RunnerResult; providerUsed: string | null; modelUsed: string | null }> {
     const stageDef = this.getStageDefinition(run, stageName);
     const timeoutMs = stageDef?.timeoutMs ?? 120_000;
 
@@ -644,13 +655,16 @@ export class HarnessOrchestrator {
       const command = stageDef.templateOrCommand === "$testCommand"
         ? run.testCommand
         : stageDef.templateOrCommand;
-      return runTestCommand(command, run.repoPath, timeoutMs, logDir);
+      return { result: await runTestCommand(command, run.repoPath, timeoutMs, logDir), providerUsed: null, modelUsed: null };
     }
 
-    // TEMP: force claude with default model + medium thinking
-    const providerId = run.runnerMode === "mock" ? "mock" : "claude";
-    const model = undefined;
-    const thinkingLevel = "medium";
+    // Resolve provider config: stage-level override → run-level config → runner mode
+    const providerId = run.runnerMode === "mock"
+      ? "mock"
+      : (stageDef?.provider ?? run.runnerMode);
+    const model = stageDef?.model ?? run.model ?? undefined;
+    const thinkingLevel = stageDef?.thinkingLevel ?? run.thinkingLevel ?? undefined;
+    console.log(`[orchestrator] executeStage ${stageName}: provider=${providerId} model=${model} thinking=${thinkingLevel} (runnerMode=${run.runnerMode}, stageDef.provider=${stageDef?.provider})`);
 
     // Mock or provider-based execution
     let result: RunnerResult;
@@ -659,7 +673,7 @@ export class HarnessOrchestrator {
     } else {
       const provider = getProvider(providerId);
       if (!provider) {
-        return { success: false, output: "", logs: "", error: `Unknown provider: ${providerId}` };
+        return { result: { success: false, output: "", logs: "", error: `Unknown provider: ${providerId}` }, providerUsed: providerId, modelUsed: model ?? null };
       }
       result = await runProviderPrompt(provider, prompt, run.repoPath, timeoutMs, model, thinkingLevel, logDir);
     }
@@ -671,10 +685,9 @@ export class HarnessOrchestrator {
       // failIfOutputContains check
       if (failIfOutputContains && result.success && result.output.toUpperCase().includes(failIfOutputContains.toUpperCase())) {
         return {
-          success: false,
-          output: result.output,
-          logs: result.logs,
-          error: `${stageName} found blocker findings`,
+          result: { ...result, success: false, error: `${stageName} found blocker findings` },
+          providerUsed: providerId,
+          modelUsed: model ?? null,
         };
       }
 
@@ -684,10 +697,9 @@ export class HarnessOrchestrator {
         const matched = failIfOutputContainsAny.find((keyword) => upperOutput.includes(keyword.toUpperCase()));
         if (matched) {
           return {
-            success: false,
-            output: result.output,
-            logs: result.logs,
-            error: `${stageName} found ${matched.replace(":", "").toLowerCase()} findings`,
+            result: { ...result, success: false, error: `${stageName} found ${matched.replace(":", "").toLowerCase()} findings` },
+            providerUsed: providerId,
+            modelUsed: model ?? null,
           };
         }
       }
@@ -700,26 +712,32 @@ export class HarnessOrchestrator {
             run.prUrl = urlMatch[0];
             await this.store.saveRun(run);
           }
-          return result;
+          return { result, providerUsed: providerId, modelUsed: model ?? null };
         }
         // Simulated PR URL fallback
         const suffix = run.id.split("-")[0];
         return {
-          success: true,
-          output: `${result.output}\n\nsimulated_pr_url: https://example.com/pr/${suffix}`,
-          logs: result.logs,
-          error: "",
+          result: {
+            success: true,
+            output: `${result.output}\n\nsimulated_pr_url: https://example.com/pr/${suffix}`,
+            logs: result.logs,
+            error: "",
+          },
+          providerUsed: providerId,
+          modelUsed: model ?? null,
         };
       }
     }
 
-    return result;
+    return { result, providerUsed: providerId, modelUsed: model ?? null };
   }
 
   private async applyStageResult(
     runId: string,
     stageName: string,
     result: RunnerResult,
+    providerUsed: string | null,
+    modelUsed: string | null,
   ): Promise<void> {
     const run = await this.requireRun(runId);
     const stage = run.stages.find((item) => item.name === stageName);
@@ -747,6 +765,12 @@ export class HarnessOrchestrator {
     attempt.outputPreview = result.output;
     attempt.logsPreview = result.logs;
     attempt.error = result.error;
+    attempt.costUsd = result.costUsd ?? null;
+    attempt.inputTokens = result.inputTokens ?? null;
+    attempt.outputTokens = result.outputTokens ?? null;
+    attempt.durationMs = result.durationMs ?? null;
+    attempt.providerUsed = providerUsed;
+    attempt.modelUsed = modelUsed;
 
     await this.appendProgress(runId, stageName, attempt.attempt, result);
 

--- a/lib/harness/orchestrator.ts
+++ b/lib/harness/orchestrator.ts
@@ -2,7 +2,7 @@ import { appendFile, mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 import type { StageDefinition } from "@/lib/harness/pipeline-templates";
-import { getTemplateOrDefault } from "@/lib/harness/pipeline-templates";
+import { getTemplateOrDefault, stageRequiresAgentBrowser } from "@/lib/harness/pipeline-templates";
 import { buildRepoContext, latestOutput, loadStageTemplate, renderTemplate } from "@/lib/harness/prompts";
 import { getProvider } from "@/lib/harness/providers";
 import { runMockStage, runProviderPrompt, runTestCommand } from "@/lib/harness/runners";
@@ -19,6 +19,11 @@ import type {
   StageRun,
 } from "@/lib/harness/types";
 import { provisionWorktree, teardownWorktree } from "@/lib/harness/workspace-manager";
+import { detectRuntimeCapabilities } from "@/lib/harness/capabilities";
+
+const DEFAULT_APP_BASE_URL = "http://127.0.0.1:3000";
+const DEFAULT_APP_START_COMMAND = "pnpm dev";
+const DEFAULT_APP_READY_PATTERN = "ready";
 
 export interface CreateRunInput {
   ticket: string;
@@ -57,9 +62,32 @@ function appendEvent(run: RunRecord, event: Omit<RunEvent, "timestamp">): void {
   });
 }
 
+function parseStatusDeclaration(output: string): "done" | "retry" | "failed" | null {
+  const match = output.match(/(?:^|\n)\s*STATUS:\s*(done|retry|failed)\s*(?:\n|$)/i);
+  if (!match) return null;
+  return match[1].toLowerCase() as "done" | "retry" | "failed";
+}
+
+function hasVerifyBrowserBlockVerdict(output: string): boolean {
+  if (!/(?:^|\n)\s*##\s*Verdict\b/i.test(output)) return false;
+  return /(?:^|\n)\s*-\s*block\s*(?:\n|$)/i.test(output);
+}
+
+/**
+ * Shared active-run set that survives hot reloads. Without this, a hot reload
+ * creates a new orchestrator with a fresh `active` set while the old
+ * orchestrator's `executeLoop` is still running — allowing a second loop to
+ * start for the same run and causing stages to execute concurrently.
+ */
+const globalForActive = globalThis as { __harness_active_runs__?: Set<string> };
+if (!globalForActive.__harness_active_runs__) {
+  globalForActive.__harness_active_runs__ = new Set<string>();
+}
+const sharedActiveRuns: Set<string> = globalForActive.__harness_active_runs__;
+
 export class HarnessOrchestrator {
   private store: JsonRunStore;
-  private active = new Set<string>();
+  private active: Set<string> = sharedActiveRuns;
 
   constructor(store: JsonRunStore) {
     this.store = store;
@@ -120,20 +148,9 @@ export class HarnessOrchestrator {
     let worktree: RunRecord["worktree"] = null;
     let repo: RepoConfig | null = null;
 
-    if (input.repoId) {
-      repo = await this.store.getRepo(input.repoId);
-      if (!repo) {
-        throw new Error("repo not found");
-      }
-      repoId = repo.id;
-      const worktreeInfo = await provisionWorktree(repo, runId);
-      worktree = worktreeInfo;
-      repoPath = worktreeInfo.worktreePath;
-    }
-
     const template = getTemplateOrDefault(input.templateId);
 
-    // Merge per-stage overrides into template stages before snapshotting
+    // Merge per-stage overrides into template stages before snapshotting.
     const mergedStages = template.stages.map((def) => {
       const ov = input.stageOverrides?.[def.name];
       if (!ov) return def;
@@ -145,6 +162,30 @@ export class HarnessOrchestrator {
         ...(ov.timeoutMs ? { timeoutMs: ov.timeoutMs } : {}),
       };
     });
+
+    if (mergedStages.some(stageRequiresAgentBrowser)) {
+      const capabilities = await detectRuntimeCapabilities();
+      if (!capabilities.agentBrowser.available) {
+        throw new Error(
+          [
+            "This template requires agent-browser, but it is not installed.",
+            `Install: ${capabilities.agentBrowser.installCommand}`,
+            `Setup: ${capabilities.agentBrowser.setupCommand}`,
+          ].join(" "),
+        );
+      }
+    }
+
+    if (input.repoId) {
+      repo = await this.store.getRepo(input.repoId);
+      if (!repo) {
+        throw new Error("repo not found");
+      }
+      repoId = repo.id;
+      const worktreeInfo = await provisionWorktree(repo, runId);
+      worktree = worktreeInfo;
+      repoPath = worktreeInfo.worktreePath;
+    }
 
     const run: RunRecord = {
       id: runId,
@@ -427,7 +468,7 @@ export class HarnessOrchestrator {
         const isShellCommand = stageDef?.executionType === "shell-command";
         const prompt = isShellCommand
           ? (stageDef?.templateOrCommand === "$testCommand" ? run.testCommand : stageDef?.templateOrCommand ?? "")
-          : (next.promptOverride ?? (await this.buildPrompt(run, next.name)));
+          : (next.promptOverride ?? (await this.buildPrompt(run, next.name, attemptDir)));
         await writeFile(path.join(attemptDir, "prompt.txt"), prompt, "utf8");
 
         const attempt: StageAttempt = {
@@ -477,10 +518,17 @@ export class HarnessOrchestrator {
     }
   }
 
-  private async buildPrompt(run: RunRecord, stageName: string): Promise<string> {
+  private async buildPrompt(run: RunRecord, stageName: string, attemptDir: string): Promise<string> {
     const stageDef = this.getStageDefinition(run, stageName);
     const templateName = stageDef?.templateOrCommand ?? stageName.toLowerCase();
-    const template = await loadStageTemplate(templateName);
+    const [template, repo, capabilities] = await Promise.all([
+      loadStageTemplate(templateName),
+      this.resolveRunRepo(run),
+      detectRuntimeCapabilities(),
+    ]);
+    const appBaseUrl = repo?.appBaseUrl?.trim() || DEFAULT_APP_BASE_URL;
+    const appStartCommand = repo?.appStartCommand?.trim() || DEFAULT_APP_START_COMMAND;
+    const appReadyPattern = repo?.appReadyPattern?.trim() || DEFAULT_APP_READY_PATTERN;
 
     // Build dynamic variable map from all prior stages
     const vars: Record<string, string> = {
@@ -492,6 +540,13 @@ export class HarnessOrchestrator {
       feedback: this.buildFeedback(run, stageName),
       pr_instructions: this.buildPrInstructions(run),
       pr_url: run.prUrl ?? "",
+      app_base_url: appBaseUrl,
+      app_start_command: appStartCommand,
+      app_ready_pattern: appReadyPattern,
+      attempt_dir: attemptDir,
+      agent_browser_available: capabilities.agentBrowser.available ? "true" : "false",
+      agent_browser_install_command: capabilities.agentBrowser.installCommand,
+      agent_browser_setup_command: capabilities.agentBrowser.setupCommand,
     };
 
     // Inject outputs from all prior stages as {{<name_lowercase>_artifact}}
@@ -650,6 +705,26 @@ export class HarnessOrchestrator {
     const stageDef = this.getStageDefinition(run, stageName);
     const timeoutMs = stageDef?.timeoutMs ?? 120_000;
 
+    if (stageDef?.requiresAgentBrowser) {
+      const capabilities = await detectRuntimeCapabilities();
+      if (!capabilities.agentBrowser.available) {
+        return {
+          result: {
+            success: false,
+            output: "",
+            logs: "",
+            error: [
+              `${stageName} requires agent-browser, but it is not installed.`,
+              `Install: ${capabilities.agentBrowser.installCommand}`,
+              `Setup: ${capabilities.agentBrowser.setupCommand}`,
+            ].join(" "),
+          },
+          providerUsed: null,
+          modelUsed: null,
+        };
+      }
+    }
+
     // Shell-command execution (e.g. Test stage)
     if (stageDef?.executionType === "shell-command") {
       const command = stageDef.templateOrCommand === "$testCommand"
@@ -676,6 +751,30 @@ export class HarnessOrchestrator {
         return { result: { success: false, output: "", logs: "", error: `Unknown provider: ${providerId}` }, providerUsed: providerId, modelUsed: model ?? null };
       }
       result = await runProviderPrompt(provider, prompt, run.repoPath, timeoutMs, model, thinkingLevel, logDir);
+    }
+
+    const statusDeclaration = parseStatusDeclaration(result.output);
+    if (statusDeclaration === "failed") {
+      return {
+        result: { ...result, success: false, error: `${stageName} reported STATUS: failed` },
+        providerUsed: providerId,
+        modelUsed: model ?? null,
+      };
+    }
+    if (statusDeclaration === "retry") {
+      return {
+        result: { ...result, success: false, error: `${stageName} reported STATUS: retry` },
+        providerUsed: providerId,
+        modelUsed: model ?? null,
+      };
+    }
+
+    if (stageDef?.templateOrCommand === "verify-browser" && hasVerifyBrowserBlockVerdict(result.output)) {
+      return {
+        result: { ...result, success: false, error: `${stageName} reported Verdict: block` },
+        providerUsed: providerId,
+        modelUsed: model ?? null,
+      };
     }
 
     // Apply success criteria generically
@@ -817,6 +916,13 @@ export class HarnessOrchestrator {
       writeFile(logsPath, logs, "utf8"),
     ]);
     return { artifactPath, logsPath };
+  }
+
+  private async resolveRunRepo(run: RunRecord): Promise<RepoConfig | null> {
+    if (!run.repoId) {
+      return null;
+    }
+    return this.store.getRepo(run.repoId);
   }
 
   private progressPath(runId: string): string {

--- a/lib/harness/pipeline-templates.ts
+++ b/lib/harness/pipeline-templates.ts
@@ -17,6 +17,7 @@ export interface StageDefinition {
   provider?: string;
   model?: string;
   thinkingLevel?: string;
+  requiresAgentBrowser?: boolean;
 }
 
 export interface PipelineTemplate {
@@ -30,17 +31,18 @@ export const BUILTIN_TEMPLATES: PipelineTemplate[] = [
   {
     id: "feature",
     label: "Feature",
-    description: "Full pipeline: Plan, Implement, Verify, Test, PR, Review",
+    description: "Full pipeline: Plan, Implement, Verify (browser), Test, PR, Review",
     stages: [
       { name: "Plan", executionType: "claude-prompt", templateOrCommand: "plan", timeoutMs: 600_000 },
       { name: "Implement", executionType: "claude-prompt", templateOrCommand: "implement", timeoutMs: 900_000 },
       {
         name: "Verify",
         executionType: "claude-prompt",
-        templateOrCommand: "verify",
+        templateOrCommand: "verify-browser",
         timeoutMs: 600_000,
         successCriteria: { failIfOutputContains: "BLOCKER:" },
         onFailure: { revertTo: "Implement", maxCycles: 3 },
+        requiresAgentBrowser: true,
       },
       {
         name: "Test",
@@ -158,4 +160,12 @@ export function getTemplateOrDefault(id?: string | null): PipelineTemplate {
     if (found) return found;
   }
   return BUILTIN_TEMPLATES.find((t) => t.id === DEFAULT_TEMPLATE_ID)!;
+}
+
+export function stageRequiresAgentBrowser(stage: StageDefinition): boolean {
+  return stage.requiresAgentBrowser === true;
+}
+
+export function templateRequiresAgentBrowser(template: PipelineTemplate): boolean {
+  return template.stages.some(stageRequiresAgentBrowser);
 }

--- a/lib/harness/providers.ts
+++ b/lib/harness/providers.ts
@@ -34,7 +34,7 @@ export interface ProviderInfo {
 }
 
 // ---------------------------------------------------------------------------
-// Shared stream-json parser (Claude & Gemini)
+// Shared stream-json parser (Claude)
 // ---------------------------------------------------------------------------
 
 interface StreamJsonEvent {
@@ -287,38 +287,11 @@ const codexProvider: ProviderInfo = {
   parseOutput: parseCodexOutput,
 };
 
-const geminiProvider: ProviderInfo = {
-  id: "gemini",
-  label: "Gemini",
-  binary: "gemini",
-  available: false,
-  defaultModel: "gemini-2.5-pro",
-  models: [
-    // Gemini CLI configures thinking via ~/.gemini/settings.json, not CLI flags.
-    // No way to pass per-run thinking level as an argument, so we expose none.
-    { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro", thinkingLevels: [] },
-    { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash", thinkingLevels: [] },
-    { id: "gemini-3-pro-preview", label: "Gemini 3 Pro Preview", thinkingLevels: [] },
-  ],
-  buildArgs(prompt: string, model?: string): string[] {
-    const args = ["-p", "--output-format", "stream-json"];
-    if (model) {
-      args.push("--model", model);
-    }
-    args.push(prompt);
-    return args;
-  },
-  buildEnv(): Record<string, string> {
-    return {};
-  },
-  parseOutput: parseStreamJsonOutput,
-};
-
 // ---------------------------------------------------------------------------
 // Registry
 // ---------------------------------------------------------------------------
 
-const ALL_PROVIDERS: ProviderInfo[] = [claudeProvider, codexProvider, geminiProvider];
+const ALL_PROVIDERS: ProviderInfo[] = [claudeProvider, codexProvider];
 
 function whichBinary(binary: string): Promise<boolean> {
   return new Promise((resolve) => {

--- a/lib/harness/providers.ts
+++ b/lib/harness/providers.ts
@@ -11,6 +11,16 @@ export interface ProviderModel {
   thinkingLevels: ProviderThinkingLevel[];
 }
 
+export interface ParsedProviderOutput {
+  output: string;
+  success: boolean;
+  error: string;
+  costUsd?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+  durationMs?: number;
+}
+
 export interface ProviderInfo {
   id: string;
   label: string;
@@ -20,7 +30,7 @@ export interface ProviderInfo {
   models: ProviderModel[];
   buildArgs(prompt: string, model?: string, thinkingLevel?: string): string[];
   buildEnv(thinkingLevel?: string): Record<string, string>;
-  parseOutput(raw: string): { output: string; success: boolean; error: string };
+  parseOutput(raw: string): ParsedProviderOutput;
 }
 
 // ---------------------------------------------------------------------------
@@ -39,7 +49,7 @@ interface StreamJsonEvent {
   is_error?: boolean;
 }
 
-export function parseStreamJsonOutput(raw: string): { output: string; success: boolean; error: string } {
+export function parseStreamJsonOutput(raw: string): ParsedProviderOutput {
   const lines = raw.split("\n").filter((l) => l.trim());
   const events: StreamJsonEvent[] = [];
 
@@ -67,16 +77,23 @@ export function parseStreamJsonOutput(raw: string): { output: string; success: b
 
   // Use the last result event if multiple are emitted.
   const resultEvent = [...events].reverse().find((e) => e.type === "result");
+
+  // Extract metadata from result event
+  const costUsd = resultEvent?.total_cost_usd;
+  const durationMs = resultEvent?.duration_ms;
+
   if (resultEvent) {
     if (resultEvent.subtype === "error" || resultEvent.is_error) {
       return {
         output: resultEvent.result || output || "",
         success: false,
         error: resultEvent.result || "Provider returned an error result",
+        costUsd,
+        durationMs,
       };
     }
     const finalOutput = resultEvent.result || output || "";
-    return { output: finalOutput, success: true, error: "" };
+    return { output: finalOutput, success: true, error: "", costUsd, durationMs };
   }
 
   if (output.length > 0) {
@@ -96,6 +113,12 @@ interface CodexEvent {
   text?: string;
   message?: string;
   status?: string;
+  // Token usage from turn.completed events
+  usage?: {
+    input_tokens?: number;
+    cached_input_tokens?: number;
+    output_tokens?: number;
+  };
   // Newer Codex CLI wraps events in an item envelope
   item?: {
     type?: string;
@@ -109,15 +132,33 @@ interface CodexEvent {
   };
 }
 
-function parseCodexOutput(raw: string): { output: string; success: boolean; error: string } {
+function parseCodexOutput(raw: string): ParsedProviderOutput {
   const lines = raw.split("\n").filter((l) => l.trim());
   const textParts: string[] = [];
   let hasError = false;
   let errorMsg = "";
+  let totalInputTokens = 0;
+  let totalOutputTokens = 0;
 
   for (const line of lines) {
     try {
       const event = JSON.parse(line) as CodexEvent;
+
+      // Extract token counts from turn.completed events
+      if (event.type === "turn.completed" && event.usage) {
+        totalInputTokens += event.usage.input_tokens ?? 0;
+        totalOutputTokens += event.usage.output_tokens ?? 0;
+        continue;
+      }
+
+      // Skip lifecycle events that don't carry content
+      if (event.type === "thread.started" || event.type === "turn.started" || event.type === "turn.failed") {
+        if (event.type === "turn.failed") {
+          hasError = true;
+          errorMsg = event.message || "Codex turn failed";
+        }
+        continue;
+      }
 
       // Newer format: {type: "item.completed", item: {type: "agent_message", text: "..."}}
       if (event.item) {
@@ -155,16 +196,18 @@ function parseCodexOutput(raw: string): { output: string; success: boolean; erro
   }
 
   const output = textParts.join("\n");
+  const inputTokens = totalInputTokens > 0 ? totalInputTokens : undefined;
+  const outputTokens = totalOutputTokens > 0 ? totalOutputTokens : undefined;
 
   if (hasError && !output) {
-    return { output: "", success: false, error: errorMsg };
+    return { output: "", success: false, error: errorMsg, inputTokens, outputTokens };
   }
 
   if (output.length > 0) {
-    return { output, success: !hasError, error: hasError ? errorMsg : "" };
+    return { output, success: !hasError, error: hasError ? errorMsg : "", inputTokens, outputTokens };
   }
 
-  return { output: "", success: false, error: "No output from Codex" };
+  return { output: "", success: false, error: "No output from Codex", inputTokens, outputTokens };
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/harness/runners.ts
+++ b/lib/harness/runners.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 
 import type { StageDefinition } from "@/lib/harness/pipeline-templates";
-import type { ProviderInfo } from "@/lib/harness/providers";
+import type { ParsedProviderOutput, ProviderInfo } from "@/lib/harness/providers";
 import { getProvider, parseStreamJsonOutput } from "@/lib/harness/providers";
 import type { RunnerResult } from "@/lib/harness/types";
 
@@ -77,7 +77,7 @@ function parseProviderOutput(
   provider: ProviderInfo,
   stdout: string,
   stderr: string,
-): { output: string; success: boolean; error: string } {
+): ParsedProviderOutput {
   const parsedStdout = provider.parseOutput(stdout);
   if (parsedStdout.success) {
     return parsedStdout;
@@ -175,6 +175,10 @@ export async function runProviderPrompt(
           output: safeArtifactOutput(parsed.output, stdout),
           logs,
           error: `command timed out after ${Math.round(timeoutMs / 1000)}s`,
+          costUsd: parsed.costUsd,
+          inputTokens: parsed.inputTokens,
+          outputTokens: parsed.outputTokens,
+          durationMs: parsed.durationMs,
         });
         return;
       }
@@ -191,6 +195,10 @@ export async function runProviderPrompt(
           output: safeArtifactOutput(parsed.output, stdout),
           logs,
           error: resolvedError,
+          costUsd: parsed.costUsd,
+          inputTokens: parsed.inputTokens,
+          outputTokens: parsed.outputTokens,
+          durationMs: parsed.durationMs,
         });
         return;
       }
@@ -216,6 +224,10 @@ export async function runProviderPrompt(
         output: safeArtifactOutput(parsed.output, stdout),
         logs,
         error: resolvedError,
+        costUsd: parsed.costUsd,
+        inputTokens: parsed.inputTokens,
+        outputTokens: parsed.outputTokens,
+        durationMs: parsed.durationMs,
       });
     });
   });

--- a/lib/harness/singleton.ts
+++ b/lib/harness/singleton.ts
@@ -1,9 +1,11 @@
 import path from "node:path";
 
+import { detectRuntimeCapabilities } from "@/lib/harness/capabilities";
 import { HarnessOrchestrator } from "@/lib/harness/orchestrator";
 import type { ProviderInfo } from "@/lib/harness/providers";
 import { detectProviders, getAllProviders } from "@/lib/harness/providers";
 import { JsonRunStore } from "@/lib/harness/store";
+import type { RuntimeCapabilitiesData } from "@/lib/harness/types";
 
 const globalForHarness = globalThis as {
   __harness_orchestrator__?: HarnessOrchestrator;
@@ -37,4 +39,8 @@ export async function getAvailableProviders(): Promise<ProviderInfo[]> {
     globalForHarness.__harness_providers_detected__ = true;
   }
   return globalForHarness.__harness_providers__ ?? getAllProviders();
+}
+
+export async function getRuntimeCapabilities(): Promise<RuntimeCapabilitiesData> {
+  return detectRuntimeCapabilities();
 }

--- a/lib/harness/singleton.ts
+++ b/lib/harness/singleton.ts
@@ -7,24 +7,26 @@ import { JsonRunStore } from "@/lib/harness/store";
 
 const globalForHarness = globalThis as {
   __harness_orchestrator__?: HarnessOrchestrator;
-  __harness_version__?: number;
+  __harness_ctor__?: typeof HarnessOrchestrator;
   __harness_providers__?: ProviderInfo[];
   __harness_providers_detected__?: boolean;
 };
 
-// Bump this when runner/orchestrator behavior changes so the
-// singleton is recreated after hot-reload in dev mode.
-const CODE_VERSION = 6;
-
+/**
+ * Returns a cached orchestrator singleton. Automatically recreates it when
+ * the HarnessOrchestrator class reference changes (i.e. the module was
+ * re-evaluated via hot reload), so code changes take effect without needing
+ * a manual version bump or server restart.
+ */
 export function getOrchestrator(): HarnessOrchestrator {
   if (
     !globalForHarness.__harness_orchestrator__ ||
-    globalForHarness.__harness_version__ !== CODE_VERSION
+    globalForHarness.__harness_ctor__ !== HarnessOrchestrator
   ) {
     const storePath = path.join(process.cwd(), ".data", "store.json");
     const store = new JsonRunStore(storePath);
     globalForHarness.__harness_orchestrator__ = new HarnessOrchestrator(store);
-    globalForHarness.__harness_version__ = CODE_VERSION;
+    globalForHarness.__harness_ctor__ = HarnessOrchestrator;
   }
   return globalForHarness.__harness_orchestrator__;
 }

--- a/lib/harness/types.ts
+++ b/lib/harness/types.ts
@@ -22,6 +22,12 @@ export interface StageAttempt {
   outputPreview: string;
   logsPreview: string;
   error: string;
+  costUsd: number | null;
+  inputTokens: number | null;
+  outputTokens: number | null;
+  durationMs: number | null;
+  providerUsed: string | null;
+  modelUsed: string | null;
 }
 
 export interface StageRun {
@@ -96,6 +102,10 @@ export interface RunnerResult {
   output: string;
   logs: string;
   error: string;
+  costUsd?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+  durationMs?: number;
 }
 
 export interface StageOverride {

--- a/lib/harness/types.ts
+++ b/lib/harness/types.ts
@@ -5,7 +5,7 @@ export const DEFAULT_STAGE_ORDER = ["Plan", "Implement", "Verify", "Test", "PR"]
 export const STAGE_ORDER = DEFAULT_STAGE_ORDER;
 
 export type StageName = string;
-export type RunnerMode = "mock" | "claude" | "codex" | "gemini";
+export type RunnerMode = "mock" | "claude" | "codex";
 export type PrMode = "simulate" | "create";
 export type RunStatus = "queued" | "running" | "failed" | "done" | "cancelled";
 export type StageStatus = "queued" | "running" | "failed" | "done" | "skipped";

--- a/lib/harness/types.ts
+++ b/lib/harness/types.ts
@@ -57,6 +57,9 @@ export interface RepoConfig {
   setupScript: string;
   envFiles: string[];
   defaultTestCommand: string;
+  appBaseUrl?: string;
+  appStartCommand?: string;
+  appReadyPattern?: string;
   createdAt: string;
   updatedAt: string;
 }
@@ -127,4 +130,15 @@ export interface ProviderData {
     label: string;
     thinkingLevels: { id: string; label: string }[];
   }[];
+}
+
+export interface AgentBrowserCapabilityData {
+  available: boolean;
+  binary: string;
+  installCommand: string;
+  setupCommand: string;
+}
+
+export interface RuntimeCapabilitiesData {
+  agentBrowser: AgentBrowserCapabilityData;
 }

--- a/prompt-templates/CONTRACTS.md
+++ b/prompt-templates/CONTRACTS.md
@@ -17,6 +17,13 @@ from the orchestrator. Missing keys render as empty strings.
 | `repo_context` | RunRecord | Repository summary (tech stack, structure) |
 | `progress_path` | RunRecord | Path to progress tracking file |
 | `feedback` | buildFeedback() | Markdown summary of prior failed attempts |
+| `attempt_dir` | Orchestrator | Current stage attempt directory (`runs/<runId>/<stage>/attempt-<n>`) |
+| `app_base_url` | RepoConfig/default | Target app URL for browser verification |
+| `app_start_command` | RepoConfig/default | Command to start the app for browser checks |
+| `app_ready_pattern` | RepoConfig/default | String/pattern used to determine app readiness |
+| `agent_browser_available` | Runtime capability detection | `"true"`/`"false"` capability flag |
+| `agent_browser_install_command` | Runtime capability detection | Install command to show users |
+| `agent_browser_setup_command` | Runtime capability detection | Setup command to show users |
 
 ### Stage-Specific
 | Variable | Available In | Source |
@@ -74,17 +81,19 @@ The status line establishes a convention for future contract enforcement.
 
 ### Implement (Stage 2 of 6)
 - **Type**: claude-prompt
-- **Inputs**: ticket, plan_artifact, repo_context, feedback, progress_path
+- **Inputs**: ticket, plan_artifact, repo_context, feedback, progress_path, attempt_dir, app_base_url, app_start_command, app_ready_pattern, agent_browser_available
 - **Output**: Code changes + structured markdown implementation summary
 - **Success**: No criteria -- always passes if the LLM returns output
 - **Consumed by**: Verify (as implementation_artifact), Test, PR, Review
 
 ### Verify (Stage 3 of 6)
 - **Type**: claude-prompt
-- **Inputs**: ticket, plan_artifact, implementation_artifact, feedback, progress_path
-- **Output**: Blocker findings or "No blocker findings."
+- **Template**: `verify-browser.txt` for browser-enabled templates
+- **Inputs**: ticket, plan_artifact, implementation_artifact, feedback, progress_path, attempt_dir, app_base_url, app_start_command, app_ready_pattern
+- **Output**: Browser verification report containing scenarios, evidence (`EVIDENCE_PATH:` entries), findings, and verdict
 - **Success**: Fails if output contains "BLOCKER:" (case-insensitive)
 - **On failure**: Reverts to Implement (max 3 cycles)
+- **Runtime requirement**: `agent-browser` must be installed for stages marked `requiresAgentBrowser`; run creation fails fast otherwise.
 
 ### Test (Stage 4 of 6)
 - **Type**: shell-command

--- a/prompt-templates/implement.txt
+++ b/prompt-templates/implement.txt
@@ -11,6 +11,7 @@ Your job is to write working code that fulfills the plan. You are the ONLY stage
 5. Do NOT leave TODOs, placeholders, or incomplete work.
 6. If the file {{progress_path}} exists, read it for context on prior attempts and adjust your approach.
 7. If feedback from prior attempts is provided below, you MUST address every issue raised.
+8. If `agent_browser_available` is `true` and this ticket involves UI/browser behavior, use `agent-browser` to reproduce and validate flows before finishing.
 </rules>
 
 <context>
@@ -29,12 +30,24 @@ Your job is to write working code that fulfills the plan. You are the ONLY stage
 {{feedback}}
 </feedback>
 
+<runtime>
+agent_browser_available: {{agent_browser_available}}
+agent_browser_install_command: {{agent_browser_install_command}}
+agent_browser_setup_command: {{agent_browser_setup_command}}
+app_base_url: {{app_base_url}}
+app_start_command: {{app_start_command}}
+app_ready_pattern: {{app_ready_pattern}}
+attempt_dir: {{attempt_dir}}
+</runtime>
+
 <instructions>
 1. Read the plan carefully. Understand the scope, phases, and tasks.
 2. Explore the repository to understand existing code structure and conventions.
 3. Execute the plan's tasks in order, writing all necessary code.
-4. Run any validation commands specified in the plan to verify your work.
-5. After all code changes are complete, produce the implementation summary below.
+4. For UI/browser tasks, run targeted browser validation using `agent-browser` when available.
+5. Save screenshots to `{{attempt_dir}}/evidence/` when browser validation is used.
+6. Run any validation commands specified in the plan to verify your work.
+7. After all code changes are complete, produce the implementation summary below.
 
 IMPORTANT: Your primary job is writing code. The summary is secondary -- focus your effort on correct, complete implementation.
 </instructions>
@@ -60,6 +73,9 @@ After completing all code changes, output a markdown implementation summary:
 ## Validation Results
 - `<command ran>`: <pass/fail and relevant output>
 - `<command ran>`: <pass/fail and relevant output>
+
+## Browser Validation Evidence
+- `EVIDENCE_PATH: <path>` -- <what was verified in browser> (omit this section if browser validation was not needed)
 
 STATUS: done
 </output_format>

--- a/prompt-templates/verify-browser.txt
+++ b/prompt-templates/verify-browser.txt
@@ -1,0 +1,79 @@
+<role>
+You are the Verify stage in a fixed SDLC pipeline (Stage 3 of 6).
+Your ONLY job is to verify implementation behavior in a real browser and report blocker-level issues.
+A separate Implement stage will act on your feedback -- you do NOT fix anything yourself.
+</role>
+
+<rules>
+1. DO NOT edit, modify, or create source code files.
+2. DO NOT fix issues yourself. Report them so the Implement stage can fix them.
+3. DO NOT run code formatters, linters with --fix, or any command that modifies files.
+4. You MAY run read-only validation commands and browser verification commands.
+5. Use `agent-browser` for browser interaction and evidence capture.
+6. If the file {{progress_path}} exists, read it for context on prior attempts and adjust your approach.
+7. Focus on BLOCKER-level issues only. A blocker prevents the requested feature from working as intended.
+</rules>
+
+<context>
+<ticket>
+{{ticket}}
+</ticket>
+<plan>
+{{plan_artifact}}
+</plan>
+<implementation_summary>
+{{implementation_artifact}}
+</implementation_summary>
+</context>
+
+<runtime>
+app_base_url: {{app_base_url}}
+app_start_command: {{app_start_command}}
+app_ready_pattern: {{app_ready_pattern}}
+attempt_dir: {{attempt_dir}}
+</runtime>
+
+<feedback>
+{{feedback}}
+</feedback>
+
+<instructions>
+1. Confirm the app is reachable at `{{app_base_url}}`. If needed, run `{{app_start_command}}` and wait for `{{app_ready_pattern}}`.
+2. Derive the critical user flows from the ticket and plan.
+3. Use `agent-browser` to execute those flows end-to-end.
+4. Capture screenshots for each critical flow under `{{attempt_dir}}/evidence/`.
+5. If any required behavior is missing or broken, report it as `BLOCKER:` with specific reproduction details.
+6. Output in the exact format below.
+</instructions>
+
+<output_format>
+Output MUST contain these sections in order:
+
+# Verify Browser Report
+
+## Scenarios Run
+- <scenario and result>
+- <scenario and result>
+
+## Evidence
+- EVIDENCE_PATH: <path/to/screenshot> -- <what this screenshot proves>
+- EVIDENCE_PATH: <path/to/screenshot> -- <what this screenshot proves>
+
+## Findings
+If blockers exist, list each on its own line:
+BLOCKER: <clear description, reproduction path, expected vs actual behavior>
+
+If no blockers exist, state exactly:
+No blocker findings.
+
+## Verdict
+- pass | block
+
+IMPORTANT: The pipeline detects the literal text "BLOCKER:" to determine pass/fail.
+If you include ANY line starting with "BLOCKER:" the stage will fail and revert to Implement.
+
+End your output with a status declaration:
+STATUS: done     -- if no blockers found (verification passed)
+STATUS: retry    -- if blockers found (will revert to Implement)
+STATUS: failed   -- if verification could not be completed
+</output_format>


### PR DESCRIPTION
## Summary
- Feature pipeline Verify stage now runs **browser-based validation** via `agent-browser`, capturing screenshot evidence and reporting blockers that auto-revert to Implement
- Runtime **capability detection** (`lib/harness/capabilities.ts`) checks for `agent-browser` availability and fails fast at run creation if missing
- New **repo config fields** (`appBaseUrl`, `appStartCommand`, `appReadyPattern`) let each repo configure how browser verification reaches the app
- **Evidence API** (`/api/runs/[runId]/evidence`) serves captured screenshots with path-traversal protection
- **Stage detail UI** renders evidence thumbnails inline, and the **New Run dialog** shows agent-browser availability status

## What changed (17 files)

| Area | Files | What |
|------|-------|------|
| Capability detection | `lib/harness/capabilities.ts` (new) | `detectRuntimeCapabilities()` — shells out to `which agent-browser` |
| Types | `lib/harness/types.ts` | `AgentBrowserCapabilityData`, `RuntimeCapabilitiesData` interfaces |
| Pipeline templates | `lib/harness/pipeline-templates.ts` | Feature Verify stage → `verify-browser` template, `requiresAgentBrowser` flag, helper functions |
| Orchestrator | `lib/harness/orchestrator.ts` | Fail-fast checks, new prompt variables (`app_base_url`, `attempt_dir`, etc.), `STATUS:` / `Verdict:` output parsing, hot-reload-safe active-run set |
| Singleton | `lib/harness/singleton.ts` | Exports `getRuntimeCapabilities()` |
| Prompt: verify-browser | `prompt-templates/verify-browser.txt` (new) | Full browser verification prompt with `EVIDENCE_PATH:` convention |
| Prompt: implement | `prompt-templates/implement.txt` | Runtime context block, browser validation instructions, evidence output format |
| Prompt contracts | `prompt-templates/CONTRACTS.md` | Documents new variables and updated Verify contract |
| Evidence API | `app/api/runs/[runId]/evidence/route.ts` (new) | Serves screenshot files from run directory |
| API: providers | `app/api/providers/route.ts` | Returns `capabilities` alongside providers |
| API: runs | `app/api/runs/route.ts` | Fail-fast `agent-browser` check, try/catch on `createRun` |
| API: repos | `app/api/repos/route.ts`, `app/api/repos/[repoId]/route.ts` | Accept/persist `appBaseUrl`, `appStartCommand`, `appReadyPattern` |
| UI: new-run dialog | `app/_components/new-run-dialog.tsx` | Fetches capabilities, shows agent-browser banner, blocks creation if missing |
| UI: repo management | `app/_components/repo-management-dialog.tsx` | New fields for app base URL, start command, ready pattern |
| UI: stage detail | `app/_components/stage-detail.tsx` | Parses `EVIDENCE_PATH:` lines, renders evidence thumbnail grid |
| Hook | `app/_hooks/use-repos.ts` | Passes new repo config fields |
| Docs | `README.md` | Updated pipeline table, agent-browser setup instructions |

## How to test everything

### Prerequisites
```bash
# Install agent-browser (the core dependency for this feature)
npm install -g agent-browser
agent-browser install
```

### 1. Capability detection (does it find agent-browser?)
- **With agent-browser installed:** Open the app → click "New Run" → select the **Feature** template → you should see a **green banner** saying "agent-browser detected"
- **Without agent-browser:** Run `npm uninstall -g agent-browser`, reload → select Feature template → you should see a **red banner** with install instructions, and the "Create + Start" button should be **disabled**
- **API check:** `curl http://localhost:3000/api/providers | jq .capabilities` should return `{ agentBrowser: { available: true/false, ... } }`

### 2. Repo config fields (app URL, start command, ready pattern)
- Open **Repo Management** (gear icon) → add or edit a repo
- You should see three new fields: **App Base URL** (default `http://127.0.0.1:3000`), **App Start Command** (default `pnpm dev`), **App Ready Pattern** (default `ready`)
- Save the repo, re-open it → verify the values persisted
- Check the store: `cat .data/store.json | jq '.repos[0] | {appBaseUrl, appStartCommand, appReadyPattern}'`

### 3. Fail-fast on run creation
- Uninstall agent-browser, then try to create a Feature run via the API:
  ```bash
  curl -X POST http://localhost:3000/api/runs \
    -H 'Content-Type: application/json' \
    -d '{"ticket":"test","templateId":"feature","runnerMode":"mock"}'
  ```
- Should return **400** with an error message about agent-browser being required
- Other templates (Bug Fix, Refactor, etc.) should still create fine without agent-browser

### 4. Browser Verify stage (end-to-end with a real run)
- Install agent-browser, register a repo with a working `appStartCommand`
- Create a **Feature** run with a real ticket (or mock mode for quick test)
- Watch the pipeline progress — the Verify stage should:
  - Use the `verify-browser.txt` prompt
  - Attempt to launch the app and run browser scenarios
  - Produce `EVIDENCE_PATH:` lines in its output
- In the stage detail drawer, you should see an **Evidence** section with thumbnail images

### 5. Evidence thumbnails and API
- After a Verify stage completes (even if mocked), check the stage detail drawer
- If evidence paths are in the output, thumbnails should render (or show "screenshot missing" placeholders)
- Test the API directly: `curl http://localhost:3000/api/runs/<runId>/evidence?path=<relative-path>`
- **Path traversal protection:** `curl http://localhost:3000/api/runs/<runId>/evidence?path=../../etc/passwd` should return **403**

### 6. STATUS and Verdict output parsing
- The orchestrator now parses `STATUS: done/retry/failed` and `## Verdict` blocks
- To test: run a Feature pipeline in mock mode, then check that:
  - A verify output containing `BLOCKER:` → stage fails, reverts to Implement
  - A verify output containing `STATUS: retry` → stage fails
  - A verify output with no blockers and `STATUS: done` → stage passes

### 7. Hot-reload safety (orchestrator active-run set)
- Start a run, then save a file to trigger Next.js hot reload mid-run
- The run should continue without a duplicate execution loop starting
- Previously this would cause concurrent stage execution — verify only one stage runs at a time in the logs

### 8. Implement stage prompt changes
- Create a Feature run and inspect the Implement stage's prompt (in stage detail drawer → Prompt section)
- Should contain a `<runtime>` block with `agent_browser_available`, `app_base_url`, `attempt_dir`, etc.
- Should include instructions about saving browser evidence to `{{attempt_dir}}/evidence/`

## Test plan
- [ ] Verify agent-browser detection works (green/red banner in New Run dialog)
- [ ] Verify run creation is blocked when agent-browser is missing + Feature template selected
- [ ] Verify new repo config fields save and load correctly
- [ ] Verify Feature pipeline Verify stage uses `verify-browser.txt` prompt
- [ ] Verify evidence thumbnails render in stage detail (or show missing placeholder)
- [ ] Verify evidence API serves images and rejects path traversal
- [ ] Verify STATUS/Verdict parsing correctly fails stages with blockers
- [ ] Verify hot-reload doesn't cause duplicate stage execution